### PR TITLE
Fix degree calculation

### DIFF
--- a/include/Model.py
+++ b/include/Model.py
@@ -35,11 +35,12 @@ def rfunc(KG, e):
 
 
 def get_mat(e, KG):
-    du = [1] * e
+    du = [{e_id} for e_id in range(e)]
     for tri in KG:
         if tri[0] != tri[2]:
-            du[tri[0]] += 1
-            du[tri[2]] += 1
+            du[tri[0]].add(tri[2])
+            du[tri[2]].add(tri[0])
+    du = [len(d) for d in du]
     M = {}
     for tri in KG:
         if tri[0] == tri[2]:


### PR DESCRIPTION
Hi @StephanieWyt ,

I noticed a small error in the adjacency matrix normalization, although I doubt that there will be a large performance impact. In

https://github.com/StephanieWyt/RDGCN/blob/ebbf6e7585c0acf31f9b0e59ae38b2cbf212fb18/include/Model.py#L38-L42

we calculate the degree as 
```math
du[i] = 1 + |{(h, r, t) \in KG \mid (h = i \lor t = i) \land h \neq t}|
```
i.e. the number of triples in which the entity `i` occurs _either_ as head _or_ as tail, but not both, plus 1. Thus, when there are triples `(h, r, t)` and `(h, r', t)` this will count twice.


However, when setting up the adjacency matrix

https://github.com/StephanieWyt/RDGCN/blob/ebbf6e7585c0acf31f9b0e59ae38b2cbf212fb18/include/Model.py#L43-L57

there is a one if there exists **any** triple between the two entities and no entry otherwise.


For the `zh_en` this leads to
```python
max(du) == 983
```
while the maximum degree computed from the adjacency matrix is
```python
np.unique(np.asarray(list(M.keys()))[:, 0], return_counts=True)[1].max() == 856
```

Thus, the normalization done in

https://github.com/StephanieWyt/RDGCN/blob/ebbf6e7585c0acf31f9b0e59ae38b2cbf212fb18/include/Model.py#L61-L74

is not *exactly* what was described in the [paper](https://arxiv.org/pdf/1908.08210.pdf), equation (9), but the values are slightly smaller.